### PR TITLE
fix(search): filter button initial state

### DIFF
--- a/src/components/templates/Search/Filters.tsx
+++ b/src/components/templates/Search/Filters.tsx
@@ -38,14 +38,13 @@ export default function FilterPrice({
   addFiltersToUrl?: boolean
   className?: string
 }): ReactElement {
-  const queryParams = new URLSearchParams(window.location.search)
-  const initialServiceFilter = queryParams.get('serviceType')
-
   const navigate = useNavigate()
   const [serviceSelections, setServiceSelections] = useState<string[]>([
-    initialServiceFilter // TODO this will fail when no serviceType parameter is available
+    serviceType
   ])
-  const [accessSelections, setAccessSelections] = useState<string[]>([])
+  const [accessSelections, setAccessSelections] = useState<string[]>([
+    accessType
+  ])
 
   async function applyFilter(filter: string, filterType: string) {
     filterType === 'accessType' ? setAccessType(filter) : setServiceType(filter)

--- a/src/components/templates/Search/utils.ts
+++ b/src/components/templates/Search/utils.ts
@@ -110,9 +110,9 @@ export function getSearchQuery(
   }
 
   const filters: FilterTerm[] = []
-  accessType !== undefined &&
+  if (accessType !== undefined && accessType !== '')
     filters.push(getFilterTerm('service.type', accessType))
-  serviceType !== undefined &&
+  if (serviceType !== undefined && serviceType !== '')
     filters.push(getFilterTerm('service.attributes.main.type', serviceType))
 
   const baseQueryParams = {


### PR DESCRIPTION
## Proposed Changes

  - correctly set initial state for filter buttons on search page
  - handle empty query values for accessType and serviceType
 
