### PR TITLE
feat: add verified service provider name to asset details page

### DIFF
--- a/src/components/atoms/Publisher/index.module.css
+++ b/src/components/atoms/Publisher/index.module.css
@@ -1,5 +1,6 @@
 .publisher {
   margin: 0;
+  margin-right: 1rem;
 }
 
 .publisher a {

--- a/src/components/atoms/Publisher/index.tsx
+++ b/src/components/atoms/Publisher/index.tsx
@@ -15,10 +15,12 @@ const cx = classNames.bind(styles)
 export default function Publisher({
   account,
   minimal,
+  verifiedServiceProviderName,
   className
 }: {
   account: string
   minimal?: boolean
+  verifiedServiceProviderName?: string
   className?: string
 }): ReactElement {
   const { accountId } = useWeb3()
@@ -32,6 +34,11 @@ export default function Publisher({
     if (!account) return
 
     const source = axios.CancelToken.source()
+
+    if (verifiedServiceProviderName) {
+      setName(verifiedServiceProviderName)
+      return
+    }
 
     async function getExternalName() {
       // ENS
@@ -53,7 +60,7 @@ export default function Publisher({
     return () => {
       source.cancel()
     }
-  }, [account])
+  }, [account, verifiedServiceProviderName])
 
   const styleClasses = cx({
     publisher: true,

--- a/src/components/atoms/VerifiedBadge.module.css
+++ b/src/components/atoms/VerifiedBadge.module.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  min-width: max-content;
 }
 
 .verifiedBadge {
@@ -10,9 +11,13 @@
   padding: calc(var(--spacer) / 3);
   height: calc(var(--spacer) * 1.5);
   border-radius: var(--border-radius);
+  color: var(--color-primary);
+  font-weight: var(--font-weight-bold);
+}
+
+.fillBackground {
   background: var(--color-primary);
   color: var(--brand-white);
-  font-weight: var(--font-weight-bold);
 }
 
 .verifiedBadge svg {
@@ -56,4 +61,8 @@
 
 .isInvalid svg path {
   fill: var(--brand-alert-red);
+}
+
+.loader span {
+  padding: 0;
 }

--- a/src/components/atoms/VerifiedBadge.tsx
+++ b/src/components/atoms/VerifiedBadge.tsx
@@ -4,22 +4,28 @@ import { ReactComponent as VerifiedPatch } from '../../images/patch_check.svg'
 import { ReactComponent as Cross } from '../../images/cross.svg'
 import Time from './Time'
 import styles from './VerifiedBadge.module.css'
+import Loader from './Loader'
 
 const cx = classNames.bind(styles)
 
 export default function VerifiedBadge({
   text,
+  fillBackground,
   className,
   isInvalid,
+  isLoading,
   timestamp
 }: {
   text: string
+  fillBackground?: boolean
   className?: string
   isInvalid?: boolean
+  isLoading?: boolean
   timestamp?: boolean
 }): ReactElement {
   const styleClasses = cx({
     verifiedBadge: true,
+    fillBackground,
     isInvalid,
     timestamp,
     [className]: className
@@ -28,7 +34,15 @@ export default function VerifiedBadge({
   return (
     <div className={styles.container}>
       <div className={styleClasses}>
-        {isInvalid ? <Cross /> : <VerifiedPatch />}
+        {isLoading ? (
+          <div className={styles.loader}>
+            <Loader />
+          </div>
+        ) : isInvalid ? (
+          <Cross />
+        ) : (
+          <VerifiedPatch />
+        )}
         <span>{text}</span>
         {timestamp && (
           <span className={styles.lastVerified}>

--- a/src/components/atoms/VerifiedPublisher.tsx
+++ b/src/components/atoms/VerifiedPublisher.tsx
@@ -53,7 +53,7 @@ export default function VerifiedPublisher({
       <span>verifying...</span>
     </div>
   ) : verified ? (
-    <VerifiedBadge text="Verified Publisher" />
+    <VerifiedBadge text="Verified Publisher" fillBackground />
   ) : verifyOption ? (
     <div className={styles.verifyButton}>
       <Button

--- a/src/components/molecules/FormFields/URLInput/Input.tsx
+++ b/src/components/molecules/FormFields/URLInput/Input.tsx
@@ -6,7 +6,7 @@ import styles from './Input.module.css'
 import InputGroup from '../../../atoms/Input/InputGroup'
 import isUrl from 'is-url-superb'
 
-const isSanitizedUrl = (url: string): boolean => {
+export const isSanitizedUrl = (url: string): boolean => {
   return url !== '' && isUrl(url) && !url.includes('javascript:')
 }
 

--- a/src/components/organisms/AssetContent/MetaMain.tsx
+++ b/src/components/organisms/AssetContent/MetaMain.tsx
@@ -10,8 +10,15 @@ import styles from './MetaMain.module.css'
 import VerifiedBadge from '../../atoms/VerifiedBadge'
 
 export default function MetaMain(): ReactElement {
-  const { ddo, owner, type, isAssetNetwork, isServiceSelfDescriptionVerified } =
-    useAsset()
+  const {
+    ddo,
+    owner,
+    type,
+    isAssetNetwork,
+    isServiceSelfDescriptionVerified,
+    isVerifyingSD,
+    verifiedServiceProviderName
+  } = useAsset()
   const { web3ProviderInfo } = useWeb3()
 
   const isCompute = Boolean(ddo?.findServiceByType('compute'))
@@ -55,7 +62,11 @@ export default function MetaMain(): ReactElement {
 
       <div className={styles.publisherInfo}>
         <div className={styles.byline}>
-          Published By <Publisher account={owner} />
+          Published By{' '}
+          <Publisher
+            account={owner}
+            verifiedServiceProviderName={verifiedServiceProviderName}
+          />
           <p>
             <Time date={ddo?.created} relative />
             {ddo?.created !== ddo?.updated && (
@@ -68,8 +79,12 @@ export default function MetaMain(): ReactElement {
             )}
           </p>
         </div>
-        {isServiceSelfDescriptionVerified && (
-          <VerifiedBadge text="Service Self-Description" timestamp />
+        {(isVerifyingSD || isServiceSelfDescriptionVerified) && (
+          <VerifiedBadge
+            text="Service Self-Description"
+            isLoading={isVerifyingSD}
+            timestamp={isServiceSelfDescriptionVerified}
+          />
         )}
       </div>
     </aside>

--- a/src/providers/Asset.tsx
+++ b/src/providers/Asset.tsx
@@ -20,6 +20,7 @@ import { useAddressConfig } from '../hooks/useAddressConfig'
 import { BestPrice } from '../models/BestPrice'
 import { useCancelToken } from '../hooks/useCancelToken'
 import {
+  getPublisherFromServiceSD,
   getServiceSelfDescription,
   verifyServiceSelfDescription
 } from '../utils/metadata'
@@ -38,7 +39,9 @@ interface AssetProviderValue {
   refreshInterval: number
   isAssetNetwork: boolean
   loading: boolean
+  isVerifyingSD: boolean
   isServiceSelfDescriptionVerified: boolean
+  verifiedServiceProviderName: string
   refreshDdo: (token?: CancelToken) => Promise<void>
 }
 
@@ -69,10 +72,13 @@ function AssetProvider({
   const { isDDOWhitelisted } = useAddressConfig()
   const [loading, setLoading] = useState(false)
   const [isAssetNetwork, setIsAssetNetwork] = useState<boolean>()
+  const [isVerifyingSD, setIsVerifyingSD] = useState(false)
   const [
     isServiceSelfDescriptionVerified,
     setIsServiceSelfDescriptionVerified
   ] = useState<boolean>()
+  const [verifiedServiceProviderName, setVerifiedServiceProviderName] =
+    useState<string>()
   const newCancelToken = useCancelToken()
   const fetchDdo = async (token?: CancelToken) => {
     Logger.log('[asset] Init asset, get DDO')
@@ -136,55 +142,78 @@ function AssetProvider({
     }
   }, [])
 
-  const initMetadata = useCallback(async (ddo: DDO): Promise<void> => {
+  const checkServiceSD = useCallback(async (ddo: DDO): Promise<void> => {
     if (!ddo) return
-    setLoading(true)
-    const returnedPrice = await getPrice(ddo)
-    if (
-      appConfig.allowDynamicPricing !== 'true' &&
-      returnedPrice.type === 'pool'
-    ) {
-      setError(
-        `[asset] The asset ${ddo.id} can not be displayed on this market.`
-      )
-      setDDO(undefined)
-      setLoading(false)
-      return
+    setIsVerifyingSD(true)
+
+    try {
+      const { attributes }: { attributes: MetadataMarket } =
+        ddo.findServiceByType('metadata')
+
+      const { serviceSelfDescription } = attributes.additionalInformation
+      if (serviceSelfDescription?.raw || serviceSelfDescription?.url) {
+        const requestBody = serviceSelfDescription?.url
+          ? { body: serviceSelfDescription?.url }
+          : { body: serviceSelfDescription?.raw, raw: true }
+        const { verified } = await verifyServiceSelfDescription(requestBody)
+        const serviceSelfDescriptionContent = serviceSelfDescription?.url
+          ? await getServiceSelfDescription(serviceSelfDescription?.url)
+          : serviceSelfDescription?.raw
+
+        setIsServiceSelfDescriptionVerified(
+          verified && !!serviceSelfDescriptionContent
+        )
+        const serviceProviderName = await getPublisherFromServiceSD(
+          serviceSelfDescriptionContent
+        )
+        setVerifiedServiceProviderName(serviceProviderName)
+      }
+    } catch (error) {
+      Logger.error(error)
+    } finally {
+      setIsVerifyingSD(false)
     }
-    setPrice({ ...returnedPrice })
-
-    // Get metadata from DDO
-    const { attributes }: { attributes: MetadataMarket } =
-      ddo.findServiceByType('metadata')
-    setMetadata(attributes)
-    setTitle(attributes?.main.name)
-    setType(attributes.main.type)
-    setOwner(ddo.publicKey[0].owner)
-
-    const { serviceSelfDescription } = attributes.additionalInformation
-    if (serviceSelfDescription?.raw || serviceSelfDescription?.url) {
-      const requestBody = serviceSelfDescription?.url
-        ? { body: serviceSelfDescription?.url }
-        : { body: serviceSelfDescription?.raw, raw: true }
-      const { verified } = await verifyServiceSelfDescription(requestBody)
-      const serviceSelfDescriptionContent = serviceSelfDescription?.url
-        ? await getServiceSelfDescription(serviceSelfDescription?.url)
-        : serviceSelfDescription?.raw
-      verified && !!serviceSelfDescriptionContent
-        ? setIsServiceSelfDescriptionVerified(true)
-        : setIsServiceSelfDescriptionVerified(false)
-    }
-    Logger.log('[asset] Got Metadata from DDO', attributes)
-
-    setIsInPurgatory(ddo.isInPurgatory === 'true')
-    await setPurgatory(ddo.id)
-    setLoading(false)
   }, [])
+
+  const initMetadata = useCallback(
+    async (ddo: DDO): Promise<void> => {
+      if (!ddo) return
+      setLoading(true)
+      const returnedPrice = await getPrice(ddo)
+      if (
+        appConfig.allowDynamicPricing !== 'true' &&
+        returnedPrice.type === 'pool'
+      ) {
+        setError(
+          `[asset] The asset ${ddo.id} can not be displayed on this market.`
+        )
+        setDDO(undefined)
+        setLoading(false)
+        return
+      }
+      setPrice({ ...returnedPrice })
+
+      // Get metadata from DDO
+      const { attributes } = ddo.findServiceByType('metadata')
+      setMetadata(attributes)
+      setTitle(attributes?.main.name)
+      setType(attributes.main.type)
+      setOwner(ddo.publicKey[0].owner)
+
+      Logger.log('[asset] Got Metadata from DDO', attributes)
+
+      setIsInPurgatory(ddo.isInPurgatory === 'true')
+      await setPurgatory(ddo.id)
+      setLoading(false)
+    },
+    [appConfig.allowDynamicPricing, setPurgatory]
+  )
 
   useEffect(() => {
     if (!ddo) return
     initMetadata(ddo)
-  }, [ddo, initMetadata])
+    checkServiceSD(ddo)
+  }, [ddo, checkServiceSD, initMetadata])
 
   // Check user network against asset network
   useEffect(() => {
@@ -210,9 +239,11 @@ function AssetProvider({
           purgatoryData,
           refreshInterval,
           loading,
+          isVerifyingSD,
           refreshDdo,
           isAssetNetwork,
-          isServiceSelfDescriptionVerified
+          isServiceSelfDescriptionVerified,
+          verifiedServiceProviderName
         } as AssetProviderValue
       }
     >

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -18,6 +18,7 @@ import {
   EditableMetadataLinks
 } from '@oceanprotocol/lib'
 import { complianceUri } from '../../app.config'
+import { isSanitizedUrl } from '../components/molecules/FormFields/URLInput/Input'
 
 export function transformTags(value: string): string[] {
   const originalTags = value?.split(',')
@@ -214,6 +215,32 @@ export function updateServiceSelfDescription(
   ].attributes.additionalInformation.serviceSelfDescription = { raw, url }
 
   return ddo
+}
+
+export async function getPublisherFromServiceSD(
+  serviceSD: any
+): Promise<string> {
+  if (!serviceSD) return
+
+  try {
+    const parsedServiceSD =
+      typeof serviceSD === 'string' ? JSON.parse(serviceSD) : serviceSD
+    const providedByUrl =
+      parsedServiceSD?.selfDescriptionCredential?.credentialSubject?.[
+        'gx-service-offering:providedBy'
+      ]?.['@value']
+
+    if (!isSanitizedUrl(providedByUrl)) return
+
+    const response = await axios.get(providedByUrl)
+    if (!response || response.status !== 200 || !response?.data) return
+
+    return response.data?.selfDescriptionCredential?.credentialSubject?.[
+      'gx-participant:name'
+    ]?.['@value']
+  } catch (error) {
+    Logger.error(error.message)
+  }
 }
 
 export function transformPublishFormToMetadata(


### PR DESCRIPTION
## Proposed Changes

- show provider name from a verified SD (if available) in asset details
- detach metadata loading from service SD verification in asset details page