### PR TITLE
fix: correctly set anchor tags in the table of content

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -41,7 +41,22 @@ module.exports = {
     'gatsby-transformer-sharp',
     'gatsby-transformer-json',
     {
-      resolve: `gatsby-transformer-remark`
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [
+          {
+            resolve: `gatsby-remark-table-of-contents`,
+            options: {
+              exclude: 'Table of Contents',
+              tight: false,
+              ordered: false,
+              fromHeading: 1,
+              toHeading: 6
+            }
+          },
+          `gatsby-remark-autolink-headers`
+        ]
+      }
     },
     {
       resolve: 'gatsby-plugin-svgr',

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "gatsby-plugin-sharp": "^2.14.4",
     "gatsby-plugin-svgr": "^2.1.0",
     "gatsby-plugin-webpack-size": "^2.0.1",
+    "gatsby-remark-autolink-headers": "^2.11.0",
+    "gatsby-remark-table-of-contents": "^2.0.0",
     "gatsby-source-filesystem": "^2.9.0",
     "gatsby-source-graphql": "^2.12.0",
     "gatsby-transformer-json": "^2.9.0",

--- a/src/components/molecules/PageHeader.module.css
+++ b/src/components/molecules/PageHeader.module.css
@@ -66,12 +66,20 @@
   margin-bottom: 0;
 }
 
+.homeHeader .title,
+.homeHeader .description,
+.homeHeader .powered,
+.homeHeader .previewTitle,
+.homeHeader .previewSubTitle {
+  color: var(--brand-white);
+}
+
 .title,
 .description,
 .powered,
 .previewTitle,
 .previewSubTitle {
-  color: var(--brand-white);
+  color: var(--color-primary);
 }
 
 .powered {

--- a/src/components/molecules/PageHeader.tsx
+++ b/src/components/molecules/PageHeader.tsx
@@ -59,7 +59,8 @@ export default function PageHeader({
 
   const styleClasses = cx({
     header: true,
-    center: center
+    center: center,
+    homeHeader: isHome
   })
 
   return (


### PR DESCRIPTION
Fixes #158

## Proposed Changes

  - add missing gatsby-remark-autolink-headers plugin to correctly set anchor tags in the table of content