### PR TITLE
hotfix: update default urql provider config chainId

### DIFF
--- a/chains.config.js
+++ b/chains.config.js
@@ -10,6 +10,7 @@ const chains = [
     networkId: GX_NETWORK_ID,
     nodeUri: 'https://rpc.gaiaxtestnet.oceanprotocol.com/',
     providerUri: 'https://ctd.ptw.tu-darmstadt.euprogigant.io',
+    metadataCacheUri: 'https://aquarius.euprogigant.io',
     explorerUri: 'https://blockscout.gaiaxtestnet.oceanprotocol.com/',
     isDefault: true
   }

--- a/src/components/molecules/FormFields/FilesInput/index.tsx
+++ b/src/components/molecules/FormFields/FilesInput/index.tsx
@@ -12,6 +12,7 @@ import {
   getServiceSelfDescription,
   verifyServiceSelfDescription
 } from '../../../../utils/metadata'
+import { GX_NETWORK_ID } from '../../../../../chains.config'
 
 export default function FilesInput(props: InputProps): ReactElement {
   const [field, meta, helpers] = useField(props.name)
@@ -21,7 +22,7 @@ export default function FilesInput(props: InputProps): ReactElement {
   const newCancelToken = useCancelToken()
 
   function loadFileInfo() {
-    const config = getOceanConfig(chainId || 1)
+    const config = getOceanConfig(chainId || GX_NETWORK_ID)
 
     async function validateUrl() {
       try {

--- a/src/providers/UrqlProvider.tsx
+++ b/src/providers/UrqlProvider.tsx
@@ -2,6 +2,7 @@ import { createClient, Provider, Client } from 'urql'
 import React, { useState, useEffect, ReactNode, ReactElement } from 'react'
 import { Logger } from '@oceanprotocol/lib'
 import { getOceanConfig } from '../utils/ocean'
+import { GX_NETWORK_ID } from '../../chains.config'
 
 let urqlClient: Client
 
@@ -30,7 +31,7 @@ export default function UrqlClientProvider({
   const [client, setClient] = useState<Client>()
 
   useEffect(() => {
-    const oceanConfig = getOceanConfig(1)
+    const oceanConfig = getOceanConfig(GX_NETWORK_ID)
 
     if (!oceanConfig?.subgraphUri) {
       Logger.error(

--- a/src/utils/ocean.ts
+++ b/src/utils/ocean.ts
@@ -4,7 +4,6 @@ import { AbiItem } from 'web3-utils/types'
 import Web3 from 'web3'
 import { chains } from '../../chains.config'
 import { ConfigHelperConfigOverwrite } from '../@types/Chains'
-import { metadataCacheUri } from '../../app.config'
 
 export function getOceanConfig(network: string | number): ConfigHelperConfig {
   const config = new ConfigHelper().getConfig(
@@ -24,8 +23,6 @@ export function getOceanConfig(network: string | number): ConfigHelperConfig {
   const configOverwrite = (chains as ConfigHelperConfigOverwrite[]).find(
     (c) => c.networkId === config.networkId
   )
-
-  config.metadataCacheUri = metadataCacheUri
 
   return configOverwrite
     ? {


### PR DESCRIPTION
## Proposed Changes

  - update urql provider to initialize with 2021000 chainId
  - update fallback chainId to file info check to 2021000
  - move Gaia-X testnet metadata cache uri to `chains.config.js`