### PR TITLE
fix: publish form values reset

### DIFF
--- a/content/pages/publish/form-algorithm.json
+++ b/content/pages/publish/form-algorithm.json
@@ -102,7 +102,7 @@
     {
       "name": "noPersonalData",
       "label": "Metadata confirmation",
-      "type": "terms",
+      "type": "checkbox",
       "options": [
         "I confirm that I did not provide personal data in the metadata, which will be stored permanently on-chain on the Gaia-X testnet."
       ],

--- a/content/pages/publish/form-dataset.json
+++ b/content/pages/publish/form-dataset.json
@@ -80,7 +80,7 @@
     {
       "name": "noPersonalData",
       "label": "Metadata confirmation",
-      "type": "terms",
+      "type": "checkbox",
       "options": [
         "I confirm that I did not provide personal data in the metadata, which will be stored permanently on-chain on the Gaia-X testnet."
       ],

--- a/src/components/atoms/Input/InputElement.tsx
+++ b/src/components/atoms/Input/InputElement.tsx
@@ -144,7 +144,12 @@ export default function InputElement({
       return (
         <BoxSelection
           name={name}
-          options={options as unknown as BoxSelectionOption[]}
+          options={(options as unknown as BoxSelectionOption[]).map(
+            (option) => ({
+              ...option,
+              checked: field?.value === option.name
+            })
+          )}
           {...field}
           {...props}
         />

--- a/src/components/molecules/FormFields/BoxSelection.tsx
+++ b/src/components/molecules/FormFields/BoxSelection.tsx
@@ -47,6 +47,7 @@ export default function BoxSelection({
               type="radio"
               className={styleClassesInput}
               defaultChecked={value.checked}
+              checked={value.checked}
               onChange={(event) => handleChange(event)}
               {...props}
               disabled={disabled}

--- a/src/components/molecules/FormFields/Datatoken/index.tsx
+++ b/src/components/molecules/FormFields/Datatoken/index.tsx
@@ -1,5 +1,5 @@
 import { useField } from 'formik'
-import React, { ReactElement, useEffect } from 'react'
+import React, { ReactElement, useCallback, useEffect } from 'react'
 import { utils } from '@oceanprotocol/lib'
 import { InputProps } from '../../../atoms/Input'
 import RefreshName from './RefreshName'
@@ -8,15 +8,15 @@ import styles from './index.module.css'
 export default function Datatoken(props: InputProps): ReactElement {
   const [field, meta, helpers] = useField(props.name)
 
-  async function generateName() {
+  const generateName = useCallback(async () => {
     const dataTokenOptions = utils.generateDatatokenName()
     helpers.setValue({ ...dataTokenOptions })
-  }
+  }, [helpers])
 
   // Generate new DT name & symbol on first mount
   useEffect(() => {
-    generateName()
-  }, [])
+    if (!field?.value?.name || !field?.value?.symbol) generateName()
+  }, [generateName, field?.value?.name, field?.value?.symbol])
 
   return (
     <div className={styles.datatoken}>

--- a/src/components/molecules/FormFields/ServiceSelfDescription.tsx
+++ b/src/components/molecules/FormFields/ServiceSelfDescription.tsx
@@ -94,36 +94,41 @@ export default function ServiceSelfDescription(
       <div>
         <BoxSelection
           name="serviceSelfDescriptionOptions"
-          options={serviceSelfDescriptionOptions}
+          options={serviceSelfDescriptionOptions.map((option) => ({
+            ...option,
+            checked: field.value !== '' && userSelection === option.name
+          }))}
           handleChange={(e) => {
             helpers.setValue(undefined)
             setUserSelection(e.target.value)
           }}
         />
       </div>
-      <div>
-        {userSelection === 'url' && <Input type="files" {...props} />}
-        {userSelection === 'raw' &&
-          (!isVerified ? (
-            <div className={styles.inputContainer}>
-              <Input type="textarea" {...props} placeholder="" />
-              <Button
-                disabled={!field.value}
-                style="primary"
-                onClick={(e) => handleVerify(e, field.value)}
-              >
-                {!isLoading ? 'Verify' : <Loader />}
-              </Button>
-            </div>
-          ) : (
-            <div className={styles.previewContainer}>
-              <Markdown text={getFormattedCodeString(rawServiceSDPreview)} />
-              <Button style="text" onClick={(e) => handleEdit(e)}>
-                Edit
-              </Button>
-            </div>
-          ))}
-      </div>
+      {field.value !== '' && (
+        <div>
+          {userSelection === 'url' && <Input type="files" {...props} />}
+          {userSelection === 'raw' &&
+            (!isVerified ? (
+              <div className={styles.inputContainer}>
+                <Input type="textarea" {...props} placeholder="" />
+                <Button
+                  disabled={!field.value}
+                  style="primary"
+                  onClick={(e) => handleVerify(e, field.value)}
+                >
+                  {!isLoading ? 'Verify' : <Loader />}
+                </Button>
+              </div>
+            ) : (
+              <div className={styles.previewContainer}>
+                <Markdown text={getFormattedCodeString(rawServiceSDPreview)} />
+                <Button style="text" onClick={(e) => handleEdit(e)}>
+                  Edit
+                </Button>
+              </div>
+            ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/pages/Publish/FormAlgoPublish.tsx
+++ b/src/components/pages/Publish/FormAlgoPublish.tsx
@@ -169,7 +169,13 @@ export default function FormPublish(): ReactElement {
               {...field}
               options={
                 field.type === 'boxSelection'
-                  ? dockerImageOptions
+                  ? dockerImageOptions.map((option) => {
+                      const value = values[field.name as keyof typeof values]
+                      return {
+                        ...option,
+                        checked: value && value === option.name
+                      }
+                    })
                   : field.options
               }
               component={Input}

--- a/src/components/pages/Publish/FormAlgoPublish.tsx
+++ b/src/components/pages/Publish/FormAlgoPublish.tsx
@@ -169,13 +169,7 @@ export default function FormPublish(): ReactElement {
               {...field}
               options={
                 field.type === 'boxSelection'
-                  ? dockerImageOptions.map((option) => {
-                      const value = values[field.name as keyof typeof values]
-                      return {
-                        ...option,
-                        checked: value && value === option.name
-                      }
-                    })
+                  ? dockerImageOptions
                   : field.options
               }
               component={Input}

--- a/src/components/pages/Publish/FormPublish.tsx
+++ b/src/components/pages/Publish/FormPublish.tsx
@@ -81,11 +81,13 @@ export default function FormPublish(): ReactElement {
   const accessTypeOptions = [
     {
       name: 'Download',
+      checked: false,
       title: 'Download',
       icon: <Download />
     },
     {
       name: 'Compute',
+      checked: false,
       title: 'Compute',
       icon: <Compute />
     }
@@ -148,7 +150,13 @@ export default function FormPublish(): ReactElement {
               {...field}
               options={
                 field.type === 'boxSelection'
-                  ? accessTypeOptions
+                  ? accessTypeOptions.map((option) => {
+                      const value = values[field.name as keyof typeof values]
+                      return {
+                        ...option,
+                        checked: value && value === option.name
+                      }
+                    })
                   : field.options
               }
               component={Input}

--- a/src/components/pages/Publish/FormPublish.tsx
+++ b/src/components/pages/Publish/FormPublish.tsx
@@ -102,7 +102,9 @@ export default function FormPublish(): ReactElement {
     field: FormFieldProps
   ) {
     const value =
-      field.type === 'terms' ? !JSON.parse(e.target.value) : e.target.value
+      field.type === 'checkbox' || field.type === 'terms'
+        ? !JSON.parse(e.target.value)
+        : e.target.value
 
     if (field.name === 'access' && value === 'Compute') {
       setComputeTypeSelected(true)

--- a/src/components/pages/Publish/FormPublish.tsx
+++ b/src/components/pages/Publish/FormPublish.tsx
@@ -150,13 +150,7 @@ export default function FormPublish(): ReactElement {
               {...field}
               options={
                 field.type === 'boxSelection'
-                  ? accessTypeOptions.map((option) => {
-                      const value = values[field.name as keyof typeof values]
-                      return {
-                        ...option,
-                        checked: value && value === option.name
-                      }
-                    })
+                  ? accessTypeOptions
                   : field.options
               }
               component={Input}


### PR DESCRIPTION
## Proposed Changes

  - unselect checkboxes and box selections when resetting the publish form (unless a default value is provided)
  - always show valid datatoken details on reset

