### PR TITLE
fix: only show access credits check when accountId is whitelisted

### DIFF
--- a/src/components/Asset/AssetActions/Download/index.tsx
+++ b/src/components/Asset/AssetActions/Download/index.tsx
@@ -405,7 +405,9 @@ export default function Download({
           )}
           {isContractingFeatureEnabled &&
             asset?.metadata?.additionalInformation?.saas?.paymentMode ===
-              PAYMENT_MODES.PAYPERUSE && <ContractingProvider did={asset.id} />}
+              PAYMENT_MODES.PAYPERUSE &&
+            accountId &&
+            isAccountIdWhitelisted && <ContractingProvider did={asset.id} />}
           {accountId && (
             <WhitelistIndicator
               accountId={accountId}


### PR DESCRIPTION
## Proposed Changes

  - add check for both `accountId` and `isAccountIdWhitelisted` before displaying `ContractingProvider>` component
